### PR TITLE
Fixed issue #74

### DIFF
--- a/commerce-cloud-code/app_yourshophere/cartridge/partials/plp/grid.js
+++ b/commerce-cloud-code/app_yourshophere/cartridge/partials/plp/grid.js
@@ -1,7 +1,9 @@
+const htmlUtils = require('*/cartridge/utils/html');
+
 /**
  * Render search refinements
  *
- * @returns
+ * @returns {Object} The model object
  */
 exports.createModel = () => {
     const HttpSearchParams = require('*/api/URLSearchParams');
@@ -12,7 +14,7 @@ exports.createModel = () => {
     search.search();
 
     const componentId = httpParams.get('component');
-    model.products = search.foundProducts.map((hit) => ({ tileInclude: hit.tileInclude }));
+    model.products = search.foundProducts.map((hit) => ({ tileInclude: hit.tileInclude, object: hit.object }));
     model.showMoreButton = (search.pagePosition + search.pageSize) < search.resultCount;
     // @todo makes only sense with proper page controls
     model.moreUrlFull = search.nextPageUrl('Search-Show').toString();
@@ -49,8 +51,13 @@ exports.template = (model) => `
     ${model.showMoreButton ? templateIncludeMore(model) : ''}
 `;
 
+/**
+ * Template include hit
+ * @param {Object} hit - The hit to template include
+ * @returns {string} The template include hit
+ */
 function templateIncludeHit(hit) {
-    return `${hit.tileInclude}`;
+    return htmlUtils.wrapWithDWMarker(`${hit.tileInclude}`, hit.object, 'searchhit');
 }
 
 function templateIncludeMore(model) {

--- a/commerce-cloud-code/app_yourshophere/cartridge/templates/default/tracking/isobject_searchhit.isml
+++ b/commerce-cloud-code/app_yourshophere/cartridge/templates/default/tracking/isobject_searchhit.isml
@@ -1,0 +1,1 @@
+<isobject object="${pdict.object}" view="searchhit"><isprint value="${pdict.content}" encoding="off"/></isobject>

--- a/commerce-cloud-code/app_yourshophere/cartridge/utils/html.js
+++ b/commerce-cloud-code/app_yourshophere/cartridge/utils/html.js
@@ -1,0 +1,20 @@
+/**
+ * Wrap the content with the DW marker
+ * @param {string} content - The HTML content to wrap
+ * @param {Object} object - The object to render the marker for
+ * @param {string} type -  one value of 'none' or 'searchhit' or 'recommendation' or 'setproduct' or 'detail'.
+ * @returns {string} The wrapped content
+ */
+function wrapWithDWMarker(content, object, type) {
+    const HashMap = require('dw/util/HashMap');
+    const Template = require('dw/util/Template');
+    const dataMap = new HashMap();
+    dataMap.put('object', object);
+    dataMap.put('content', content);
+    const isobject = new Template(`tracking/isobject_${type}`);
+    return isobject.render(dataMap).text;
+}
+
+module.exports = {
+    wrapWithDWMarker,
+};


### PR DESCRIPTION
Adding markers for the storefront toolkit to work.

Unfortunately `<isobject>` is the only way to do this.